### PR TITLE
prow: COSI: controller: use docker image for build presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Build test in container-object-storage-interface-controller repo.
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.18.4
+      - image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
       description: Unit tests in container-object-storage-interface-controller repo.
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.18.4
+      - image: public.ecr.aws/docker/library/golang:latest
         command:
         - make
         args:


### PR DESCRIPTION
Use image with docker for Container Object Storage Interface (COSI) build presubmit check.